### PR TITLE
Bumping NodeJS min supported version to 16

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -163,7 +163,7 @@
       "parser": "@typescript-eslint/parser",
       "extends": ["plugin:@typescript-eslint/recommended"],
       "parserOptions": {
-        "project": ["tsconfig.json", "tests/tsconfig.json"],
+        "project": ["tsconfig.json", "specs/tsconfig.json"],
         "sourceType": "module"
       }
     }

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -5,31 +5,36 @@ on:
     types: [created]
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ["14", "16", "18"]
+        node: ["16", "18", "20"]
     name: Test with node ${{ matrix.node }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
-      - run: npm ci
-      - run: npm test
+      - name: Installing dependencies
+        run: npm ci
+      - name: Linting
+        run: npm run lint
+      - name: Testing
+        run: npm test
 
-  publish-npm:
-    needs: build
+  publish:
+    needs: test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
           registry-url: https://registry.npmjs.org/
-      - run: npm ci
-      - run: npm run build
-      - run: npm publish
+      - name: Creating the production build
+        run: npm run build
+      - name: Publishing
+        run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -12,21 +12,27 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ["14", "16", "18"]
+        node: ["16", "18", "20"]
     name: Test with node v${{ matrix.node }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
-      - run: npm ci
-      - run: npm run lint
-      - run: npm test
-      - uses: coverallsapp/github-action@master
+      - name: Installing dependencies
+        run: npm ci
+      - name: Linting
+        run: npm run lint
+      - name: Testing
+        run: npm test
+      - name: Calculating coverage
+        uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.github_token }}
           flag-name: node v${{ matrix.node }}
           parallel: true
+      - name: Creating a test build
+        run: npm run build
 
   finish:
     needs: test

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "vitest": "0.31.4"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "git@github.com:RomiC/query-cast.git"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=16"
   },
   "license": "MIT",
   "main": "./dist/index.js",

--- a/specs/tsconfig.json
+++ b/specs/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.json",
+  "include": ["./**/*.spec.ts"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,7 @@
   "compilerOptions": {
     "module": "commonjs",
     "esModuleInterop": true,
-    "target": "es6",
-    "lib": ["es2015"],
+    "target": "es2015",
     "declaration": true,
     "noImplicitAny": true,
     "moduleResolution": "node",
@@ -11,6 +10,6 @@
     "outDir": "dist",
     "baseUrl": "."
   },
-  "include": ["src/**/*.ts", "specs/**/*.ts"],
+  "include": ["src/**/*.ts"],
   "exclude": ["node_modules/*"]
 }


### PR DESCRIPTION
- Bumped engines.node version in package.json
- Updated package-lock to v2
- GH Actions:
  - node versions list update to 16, 18, 20
  - Added labels to each step
  - Publishing using node v20