### PR TITLE
Chore: fix tsconfig deprecations and add missing npm ci in publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -32,6 +32,8 @@ jobs:
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org/
+      - name: Installing dependencies
+        run: npm ci
       - name: Creating the production build
         run: npm run build
       - name: Publishing

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,14 @@
 {
   "compilerOptions": {
-    "module": "commonjs",
+    "module": "node16",
     "esModuleInterop": true,
     "target": "es2015",
     "declaration": true,
     "noImplicitAny": true,
-    "moduleResolution": "node",
+    "moduleResolution": "node16",
     "sourceMap": true,
     "outDir": "dist",
-    "baseUrl": "."
+    "rootDir": "src"
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules/*"]


### PR DESCRIPTION
- Replace deprecated `module: commonjs` + `moduleResolution: node` with `node16`
- Remove deprecated `baseUrl` (unused)
- Add explicit `rootDir: src`
- Add missing `npm ci` step in publish workflow before build