### PR TITLE
Feat: [#7] Add default value support for schema params

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ You may think of it as a reducers from [`redux`](https://github.com/reduxjs/redu
 
 Create cast function based upon schema.
 
-- `schema: {[key: string]: Types | [Types]}` – describe the shape of the output. You should use the types from `Types`-enum from the lib while defining it. List of supported types below:
+- `schema: {[key: string]: Types | [Types] | { type: Types | [Types], default?: any }}` – describe the shape of the output. You should use the types from `Types`-enum from the lib while defining it. List of supported types below:
 
   - `Types.STRING` – string value will left as is
   - `Types.BOOLEAN` – convert to boolean. Any number which is greater than 0, `Infinity`, `'1'`, `'yes'`, `'+'` will be cast to `true`.
@@ -57,6 +57,28 @@ Create cast function based upon schema.
   - `Types.NUMBER` – alias of `Types.FLOAT`
   - `Types.DATE` – convert to `Date`-object
   - `Types.ANY` – the same as `Types.STRING`
+
+  You can also specify a default value for a param by passing an object with `type` and optional `default`:
+
+  ```ts
+  const cast = queryCast({
+    page: {
+      type: Types.INTEGER,
+      default: 1
+    },
+    search: {
+      type: Types.STRING,
+      default: ''
+    },
+    // Simple syntax still works
+    filter: Types.STRING
+  });
+
+  cast('?page=2');            // { page: 2, search: '', filter: undefined }
+  cast('');                   // { page: 1, search: '', filter: undefined }
+  ```
+
+  When a param is missing from the query and a `default` is specified, the default value is used. If no default is specified, the param is omitted from the result. Provided query values always override the default.
 
 ### `combineQueryCasts(casts)`
 

--- a/specs/index.spec.js
+++ b/specs/index.spec.js
@@ -164,6 +164,84 @@ describe('queryCast', () => {
     assert.deepEqual(cast('&a'), { a: '' });
   });
 
+  it('should apply default value when param is missing', () => {
+    const castWithDefaults = queryCast({
+      foo: {
+        type: Types.INTEGER,
+        default: 20
+      },
+      bar: {
+        type: Types.STRING,
+        default: 'fallback'
+      },
+      baz: {
+        type: Types.BOOLEAN,
+        default: true
+      }
+    });
+
+    assert.deepEqual(castWithDefaults(''), {
+      foo: 20,
+      bar: 'fallback',
+      baz: true
+    });
+  });
+
+  it('should use provided param value over default', () => {
+    const castWithDefaults = queryCast({
+      foo: {
+        type: Types.INTEGER,
+        default: 20
+      },
+      bar: {
+        type: Types.STRING,
+        default: 'fallback'
+      }
+    });
+
+    assert.deepEqual(castWithDefaults('?foo=42&bar=override'), {
+      foo: 42,
+      bar: 'override'
+    });
+  });
+
+  it('should mix default and non-default params', () => {
+    const castMixed = queryCast({
+      foo: {
+        type: Types.STRING,
+        default: 'a'
+      },
+      bar: Types.STRING
+    });
+
+    assert.deepEqual(castMixed('?bar=present'), {
+      foo: 'a',
+      bar: 'present'
+    });
+  });
+
+  it('should support default with object notation alongside simple syntax', () => {
+    const castSimple = queryCast({
+      foo: Types.INTEGER
+    });
+
+    assert.deepEqual(castSimple('?foo=42'), { foo: 42 });
+    assert.deepEqual(castSimple(''), {});
+  });
+
+  it('handles default with empty string as value', () => {
+    const cast = queryCast({
+      foo: {
+        type: Types.STRING,
+        default: 'default'
+      }
+    });
+
+    assert.deepEqual(cast('?foo='), { foo: '' });
+    assert.deepEqual(cast('?foo&'), { foo: '' });
+    assert.deepEqual(cast(''), { foo: 'default' });
+  });
+
   it('skips params with empty keys', () => {
     const cast = queryCast({ a: Types.STRING, d: Types.STRING, c: Types.STRING });
     assert.deepEqual(cast('a=b&=c&d=e'), { a: 'b', d: 'e' });

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,22 @@ type TypesMap = {
   [Types.STRING]: string;
 };
 
-type InferType<T> = T extends Types ? TypesMap[T] : T extends Types[] ? TypesMap[T[0]][] : never;
+interface CastFieldSchema {
+  type: Types | [Types];
+  default?: unknown;
+}
+
+type CastSchemaEntry = Types | [Types] | CastFieldSchema;
+
+type SchemaType<T> = T extends CastFieldSchema ? T['type'] : T;
+
+type InferType<T> = SchemaType<T> extends Types
+  ? TypesMap[SchemaType<T>]
+  : SchemaType<T> extends [infer E]
+    ? E extends Types
+      ? TypesMap[E][]
+      : never
+    : never;
 
 type ParsedCastQuery<S extends CastSchema> = {
   [K in keyof S]: InferType<S[K]>;
@@ -32,7 +47,7 @@ type ParsedCastQuery<S extends CastSchema> = {
  * Describe the schema of query parsing
  */
 interface CastSchema {
-  [key: string]: Types | [Types];
+  [key: string]: CastSchemaEntry;
 }
 
 /**
@@ -60,17 +75,36 @@ type QueryCastMap<S extends CastSchemaMap> = {
 
 type InferQueryCastType<T> = T extends QueryCastMap<infer S> ? { [K in keyof S]: ParsedCastQuery<S[K]> } : never;
 
+type ProcessedSchema = Record<string, { type: Types | [Types]; default?: unknown }>;
+
 export function queryCast<S extends CastSchema>(schema: S): QueryCast<S> {
   const schemaKeys = Object.keys(schema);
+
+  const processedSchema: ProcessedSchema = schemaKeys.reduce(
+    (acc, key) => {
+      const entry = schema[key];
+      if (typeof entry === 'object' && !Array.isArray(entry) && entry !== null) {
+        acc[key] = { type: entry.type, default: entry.default };
+      } else {
+        acc[key] = { type: entry, default: undefined };
+      }
+      return acc;
+    },
+    Object.create(null) as ProcessedSchema
+  );
 
   return (query: string | ParsedQuery) => {
     const parsed = typeof query === 'string' ? parseQuery(query) : query;
 
     return schemaKeys.reduce(
       (result, key) => {
+        const { type, default: defaultValue } = processedSchema[key];
         const value = parsed[key];
+
         if (value != null) {
-          result[key as keyof S] = cast(value, schema[key]);
+          result[key as keyof S] = cast(value, type);
+        } else if (defaultValue !== undefined) {
+          result[key as keyof S] = defaultValue as InferType<S[keyof S]>;
         }
 
         return result;


### PR DESCRIPTION
Closes #7

Adds support for specifying default values in the query-cast schema. Schema entries now accept an object form with `type` and optional `default`.

### Changes

- **New schema syntax:** `{ type: Types | [Types], default?: any }` — when a param is missing from the query, the default value is used
- **Type system updated:** `CastFieldSchema` interface, `SchemaType` type helper, updated `InferType` to handle both simple and object forms
- **Runtime:** pre-processes the schema to extract `type`/`default`, applies default when param is absent and a default is specified
- **5 test cases:** defaults applied when missing, explicit values override, mixed schema syntax, backward compat, empty string handling
- **README updated** with usage examples

### Example

```ts
const cast = queryCast({
  page: { type: Types.INTEGER, default: 1 },
  search: { type: Types.STRING, default: '' }
});

cast('?page=2');  // { page: 2, search: '' }
cast('');         // { page: 1, search: '' }
```

All 25 tests pass. Simple `Types.STRING` / `[Types.STRING]` syntax is fully backward compatible.