### PR TITLE
Fix: [#377] NPM publish workflow not triggered when publishing draft release

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -2,7 +2,7 @@ name: Publish to NPM
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 permissions:
   id-token: write  # Required for OIDC


### PR DESCRIPTION
Closes #377

The `npm-publish.yml` workflow was triggered on `release: [created]`, but when a draft release is published, GitHub sends a `published` event — not `created`. This caused the workflow to never run when publishing a draft.

### Fix
Changed the trigger from `created` to `published`. The `published` event fires both when:
- Publishing a draft release
- Creating a non-draft release directly

See [GitHub docs](https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads#release) for details.

### Changes
`.github/workflows/npm-publish.yml` — `release: [created]` → `release: [published]`