### PR TITLE
Change default branch from 'master' to 'main'

### DIFF
--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, edited, synchronize]
   push:
     branches:
-      - master
+      - main
 
 jobs:
   test:


### PR DESCRIPTION
After changing the default branch from `master` to `main`, the `npm-test` flow needs to be updated accordingly.