### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-test.yml
+++ b/.github/workflows/npm-test.yml
@@ -7,6 +7,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  checks: write
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/RomiC/query-cast/security/code-scanning/2](https://github.com/RomiC/query-cast/security/code-scanning/2)

Add an explicit `permissions` block in `.github/workflows/npm-test.yml` to limit `GITHUB_TOKEN` scope.  
Best single fix without changing behavior: define workflow-level minimal read permissions and grant only the one write scope needed by Coveralls status update.

For this workflow:
- Add at the root (after `on:` block, before `jobs:`):
  - `contents: read` (required for checkout/read repo content)
  - `checks: write` (commonly needed by Coveralls to publish check run/coverage status)
  
This applies to both `test` and `finish` jobs unless overridden, preserves existing workflow logic, and satisfies CodeQL’s requirement for explicit token scoping.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
